### PR TITLE
Fix: url 입력 로직 수정

### DIFF
--- a/src/components/Header/UrlInputContainer.jsx
+++ b/src/components/Header/UrlInputContainer.jsx
@@ -29,7 +29,7 @@ function UrlInputContainer({
     const trimmedInputValue = inputValue.trim();
     const urls = trimmedInputValue.match(/(https?:\/\/[^\s]+)/g) || [];
     const otherValues = trimmedInputValue
-      .split(/\s+/)
+      .split(/\n+/)
       .filter((value) => !value.match(/(https?:\/\/[^\s]+)/g));
     const inputValues = [...urls, ...otherValues];
     const numOfURL = inputValues.length;

--- a/src/components/Toast/ToastMessage.jsx
+++ b/src/components/Toast/ToastMessage.jsx
@@ -5,7 +5,7 @@ import IconButton from "../shared/Button/IconButton";
 
 function ToastMessage({ message, link }) {
   return (
-    <li className="box-border relative flex flex-col self-stretch justify-center w-full h-16 p-1 px-5 mt-4 shadow-md select-none rounded-xl bg-white/50">
+    <li className="box-border relative flex flex-col self-stretch justify-center w-full h-16 p-1 px-5 mt-4 shadow-md select-none animate-slide-top rounded-xl bg-white/50">
       <p>{message}</p>
       {link && (
         <a

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -69,7 +69,10 @@ export const isValid = (
 
   if (prevArticleDatas) {
     const isDuplicate = prevArticleDatas.some((articleData) => {
-      if (articleData.data.url === inputValue) {
+      if (
+        articleData.data.url.replace(/^https?:\/\/(www\.)?/, "") ===
+        inputValue.replace(/^https?:\/\/(www\.)?/, "")
+      ) {
         setMessageList((prev) => [
           ...prev,
           {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,16 @@ export default {
       width: {
         88: "22rem",
       },
+      keyframes: {
+        "slide-top": {
+          "0%": { transform: "translateY(100px)" },
+          "100%": { transform: "translateY(0px)" },
+        },
+      },
+      animation: {
+        "slide-top":
+          "slide-top 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both",
+      },
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION


## 개요

### Resolves: #15-01

### 변경 내역
1. 토스트 메세지 팝업 애니메이션을 추가하였습니다.
2. 복수의 url 분리 로직 , 중복 url 검사 로직을 수정하였습니다.

## 코드 변경 사항

### 1. 토스트 메세지 팝업 애니메이션 (`<ToastMessage>`)
  -  애니메이션 추가(tailwind.config.js)
    - 토스트 메세지가 아래에서 자연스럽게 추가되도록 애니메이션을 추가하였습니다.
https://github.com/team-sticky-252/readim-client/blob/8532f05edc19be4b8e60b83b05ad4c55fa2e7748/tailwind.config.js#L29-L38

  - 토스트 메세지 컴포넌트에 className 추가
https://github.com/team-sticky-252/readim-client/blob/8532f05edc19be4b8e60b83b05ad4c55fa2e7748/src/components/Toast/ToastMessage.jsx#L6-L16

### 2. 복수의 url 입력 분리 로직, 중복 url 입력 유효성 검사 로직 (`<urlUtils>`)
  - 복수의 url 입력 분리 로직
    - 기존의 공백으로 각 url들을 분리하여 개별 url로 변환하던 로직을, 개행을 기준으로 분리하도록 수정하였습니다. 
https://github.com/team-sticky-252/readim-client/blob/8532f05edc19be4b8e60b83b05ad4c55fa2e7748/src/components/Header/UrlInputContainer.jsx#L31-L33

  - 중복 url 입력 유효성 검사 로직
    - 기존 'http:// , https://' 를 제외한 url을 비교하여 검사하였으나, 기존 사항에 'www.' 을 제외한 url 주소를 비교하도록 추가하였습니다.
https://github.com/team-sticky-252/readim-client/blob/8532f05edc19be4b8e60b83b05ad4c55fa2e7748/src/utils/urlUtils.js#L72-L75

## 기타 전달 사항

<!---- 리뷰어들에게 기능관련 외에 전달하고 싶은 사항을 작성해주세요. -->

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
