### PR TITLE
Feat: InfoReadingTimeText 60분 이상일 경우 시간 단위 문구 추가

### DIFF
--- a/src/components/Header/InfoReadingTimeText.jsx
+++ b/src/components/Header/InfoReadingTimeText.jsx
@@ -2,19 +2,20 @@ import PropTypes from "prop-types";
 
 function InfoReadingTimeText({ totalReadTime }) {
   let readingMinute = Math.floor(totalReadTime / 1000 / 60);
-  let readingSeconds =
+  const readingSeconds =
     Math.round((totalReadTime / 1000 - readingMinute * 60) * 0.1) * 10;
 
   if (readingSeconds >= 30) {
     readingMinute += 1;
-    readingSeconds = 0;
-  } else {
-    readingSeconds = 0;
   }
+
+  const readingHour = Math.floor(readingMinute / 60);
+  readingMinute -= readingHour * 60;
 
   return (
     <span className="inline-block font-medium text-right text-primary">
-      {`${readingMinute}분`}
+      {readingHour !== 0 && `${readingHour}시간 `}
+      {readingMinute !== 0 && `${readingMinute}분`}
     </span>
   );
 }

--- a/src/components/Header/InfoReadingTimeText.jsx
+++ b/src/components/Header/InfoReadingTimeText.jsx
@@ -10,7 +10,7 @@ function InfoReadingTimeText({ totalReadTime }) {
   }
 
   const readingHour = Math.floor(readingMinute / 60);
-  readingMinute -= readingHour * 60;
+  readingMinute %= 60;
 
   return (
     <span className="inline-block font-medium text-right text-primary">


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈가 있다면 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 사용자의 가독성을 위해 문구를 수정했습니다.
- 60분 이상일 경우 시간, 분으로 보여줍니다.
- 60분 미만일 경우 분으로만 보여줍니다.
- xx시간 0분일 경우 시간만 보여줍니다.

[수정 전]
```
약 77분의 아티클이 모여있어요.
```

[수정 후]
```
약 1시간 17분의 아티클이 모여있어요.
```

## 코드 변경 사항

<!---- 어떻게 코드를 작성 및 수정했는지 설명해주세요. 필요한 경우 코드 라인 링크를 활용해주세요. -->
- 기존의 readingMinute에서 60을 나눈 몫으로 readingHour를 구했습니다.
- readingMinute는 나머지 할당 연산자(60으로 나눈 나머지 값)를 이용해 구했습니다.
https://github.com/team-sticky-252/readim-client/blob/8bc985725dd37eeabbb5bb5b4ff2bf50632ad4a0/src/components/Header/InfoReadingTimeText.jsx#L12-L13

## 기타 전달 사항



## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
