### PR TITLE
Fix: toast 메시지 id 랜덤값으로 변경

### DIFF
--- a/src/components/Toast/ToastContainer.jsx
+++ b/src/components/Toast/ToastContainer.jsx
@@ -51,7 +51,8 @@ export default ToastContainer;
 ToastContainer.propTypes = {
   messageList: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
+      id: PropTypes.string.isRequired,
+      icon: PropTypes.string.isRequired,
       messages: PropTypes.arrayOf(PropTypes.string).isRequired,
       link: PropTypes.string,
     }),

--- a/src/components/Toast/ToastContainer.jsx
+++ b/src/components/Toast/ToastContainer.jsx
@@ -22,7 +22,7 @@ function ToastContainer({ messageList, deleteMessage, deleteAllMessages }) {
 
   return (
     <aside
-      className={`toast-scroll-container fixed p-3 max-h-screen-margin-24 bottom-5 right-5 w-88 ${containerFadeAnimation}`}
+      className={`overflow-y-scroll fixed p-3 max-h-screen-margin-24 bottom-5 right-5 w-88 ${containerFadeAnimation}`}
     >
       {messageList.length !== 0 && (
         <div className="relative h-6">

--- a/src/components/Toast/ToastContainer.jsx
+++ b/src/components/Toast/ToastContainer.jsx
@@ -22,7 +22,7 @@ function ToastContainer({ messageList, deleteMessage, deleteAllMessages }) {
 
   return (
     <aside
-      className={`overflow-y-scroll fixed p-3 max-h-screen-margin-24 bottom-5 right-5 w-88 ${containerFadeAnimation}`}
+      className={`overflow-y-scroll fixed p-3 max-h-screen-margin-24 bottom-5 right-5 w-90 ${containerFadeAnimation}`}
     >
       {messageList.length !== 0 && (
         <div className="relative h-6">

--- a/src/components/Toast/ToastMessage.jsx
+++ b/src/components/Toast/ToastMessage.jsx
@@ -50,6 +50,7 @@ function ToastMessage({ icon, messages, link, deleteMessage }) {
 export default ToastMessage;
 
 ToastMessage.propTypes = {
+  icon: PropTypes.string.isRequired,
   messages: PropTypes.arrayOf(PropTypes.string).isRequired,
   link: PropTypes.string,
   deleteMessage: PropTypes.func.isRequired,

--- a/src/components/Toast/ToastMessage.jsx
+++ b/src/components/Toast/ToastMessage.jsx
@@ -20,7 +20,7 @@ function ToastMessage({ icon, messages, link, deleteMessage }) {
 
   return (
     <li
-      className={`group hover:scale-50 z-10 transition-all box-border relative flex items-start w-full px-5 py-2.5 mt-4 shadow-md select-none rounded-xl bg-white/80 ${messageFadeAnimation}`}
+      className={`group hover:scale-50 z-10 transition-all box-border relative flex items-start w-full px-5 pr-3 py-2.5 mt-4 shadow-md select-none rounded-xl bg-white/80 ${messageFadeAnimation}`}
     >
       <div>
         <span>{icon}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -129,15 +129,6 @@
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
       var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
-
-  .toast-scroll-container {
-    overflow: hidden;
-    transition: overflow 0.3s ease;
-  }
-
-  .toast-scroll-container:hover {
-    overflow: auto;
-  }
 }
 
 *::-webkit-scrollbar {

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -17,7 +17,7 @@ export const requestURL = async (inputValue) => {
 export const validateUrl = (inputValue, articleDataList, link = null) => {
   if (inputValue.trim() === "") {
     return {
-      id: new Date().getTime(),
+      id: crypto.randomUUID(),
       icon: ERROR_MESSAGE.BLANK.icon,
       messages: ERROR_MESSAGE.BLANK.messages,
       link,
@@ -25,7 +25,7 @@ export const validateUrl = (inputValue, articleDataList, link = null) => {
   }
   if (!inputValue.includes("http")) {
     return {
-      id: new Date().getTime(),
+      id: crypto.randomUUID(),
       icon: ERROR_MESSAGE.NOT_VALID_URL.icon,
       messages: ERROR_MESSAGE.NOT_VALID_URL.messages,
       link,
@@ -42,7 +42,7 @@ export const validateUrl = (inputValue, articleDataList, link = null) => {
     })
   ) {
     return {
-      id: new Date().getTime(),
+      id: crypto.randomUUID(),
       icon: ERROR_MESSAGE.DUPLICATE_URL.icon,
       messages: ERROR_MESSAGE.DUPLICATE_URL.messages,
       link,
@@ -51,7 +51,7 @@ export const validateUrl = (inputValue, articleDataList, link = null) => {
 
   if (articleDataList && (articleDataList.length + 1) % 30 === 0) {
     return {
-      id: new Date().getTime(),
+      id: crypto.randomUUID(),
       icon: "📚",
       message: `저장한 아티클이 ${articleDataList.length + 1}개가 넘었어요.`,
       link,
@@ -79,7 +79,7 @@ export const handleSingleURL = async (url, articleDataList, setMessageList) => {
     setMessageList((prev) => [
       ...prev,
       {
-        id: new Date().getTime(),
+        id: crypto.randomUUID(),
         icon: ERROR_MESSAGE[statusCode].icon,
         messages: ERROR_MESSAGE[statusCode].messages,
         url,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,7 +30,7 @@ export default {
       width: {
         48: "12rem",
         50: "12.5rem",
-        88: "22rem",
+        90: "22.5rem",
         140: "35rem",
         200: "50rem",
         216: "54rem",


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈가 있다면 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

id를 기존에는 new Date().getTime()으로 했으나 동일한 밀리세컨드 id를 가진 메시지가 만들어졌고
그 결과 id 키 값 중복이 발생해 토스트 메시지 삭제 시 여러 개가 동시에 삭제되는 버그가 발견됐습니다.

## 코드 변경 사항
-id를 new Date().getTime()에서 crypto.randomUUID() 로 변경했습니다.

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
