### PR TITLE
Fix: ReadingTime 컴포넌트 시간 표시 조건 수정

### DIFF
--- a/src/components/Card/ReadingTime.jsx
+++ b/src/components/Card/ReadingTime.jsx
@@ -16,13 +16,17 @@ function ReadingTime({ readingTime }) {
 
   return (
     <div className="my-3">
-      <h2 className="inline-block text-4xl font-medium">{readingMinute}</h2>
-      <p className="inline-block ml-px text-base font-light tracking-tighter">
-        분
-      </p>
+      {readingMinute !== 0 && (
+        <>
+          <h2 className="inline-block text-4xl font-medium">{readingMinute}</h2>
+          <p className="inline-block ml-px mr-2 text-base font-light tracking-tighter">
+            분
+          </p>
+        </>
+      )}
       {readingSeconds !== 0 && (
         <>
-          <h2 className="inline-block ml-2 text-4xl font-medium tracking-tighter">
+          <h2 className="inline-block text-4xl font-medium tracking-tighter">
             {readingSeconds}
           </h2>
           <p className="inline-block ml-px text-base font-light">초</p>


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈가 있다면 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

아티클 예상 읽기 시간이 30초일 경우 ReadingTime 표시가 0분 30초로 표시되고 있습니다.
0분일 경우 초만 보여주는 것으로 조건을 변경했습니다.

## 코드 변경 사항
- 0분일 경우 표시하지 않는 것으로 조건을 추가했습니다.
https://github.com/team-sticky-252/readim-client/blob/d9f7c23d880d1e9ed8c4ccbffd2a7e078582dee8/src/components/Card/ReadingTime.jsx#L19-L26

- 초를 나타내는 `<p>` 태그의 margin-left 스타일을 제거한 뒤 분을 나타내는 `<p>` 태그에 margin-right를 추가했습니다.

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
