### PR TITLE
Feat: API 응답 대기시간, OpenGraph 로직 리팩터링

### DIFF
--- a/src/utils/errorMessage.js
+++ b/src/utils/errorMessage.js
@@ -15,6 +15,10 @@ const ERROR_MESSAGE = {
     icon: "⛓️‍💥",
     messages: ["유효하지 않은 URL 이에요."],
   },
+  408: {
+    icon: "⏰",
+    messages: ["응답 요청 시간이 초과됐습니다.", "URL을 확인해주세요"],
+  },
   512: {
     icon: "⌛️",
     messages: ["리딩 타임을 측정할 수 없는 URL 이에요."],

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -73,12 +73,12 @@ export const handleSingleURL = async (url, articleDataList, setMessageList) => {
     return null;
   }
 
-  const controlloer = new AbortController();
+  const controller = new AbortController();
   const controlloerOption = {
-    signal: controlloer.signal,
+    signal: controller.signal,
   };
   const fetchTimer = setTimeout(() => {
-    controlloer.abort();
+    controller.abort();
   }, 3000);
 
   try {
@@ -109,6 +109,8 @@ export const handleSingleURL = async (url, articleDataList, setMessageList) => {
           link: url,
         },
       ]);
+    } else {
+      throw error;
     }
   } finally {
     clearTimeout(fetchTimer);


### PR DESCRIPTION
## 개요

### Resolves: #23
1. API 요청이 3초를 초과하는 경우 Toast Message를 팝업하고 요청이 종료됩니다.
2. OpenGraph 정보를 가져올 타겟을 복수로 설정할 수 있습니다.(Server Side)

## 코드 변경 사항
1. API 요청 후, 3초의 setTimeOut이 설정됩니다. 3초 후, Abort signal이 송신됩니다.
https://github.com/team-sticky-252/readim-client/blob/b6d9d45d36445ce7a29cac6ed7a43622ce291438/src/utils/urlUtils.js#L76-L87

## 기타 전달 사항

 - X

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
