### PR TITLE
Refactor: 입력창 초기화 로직, API 요청 트리거 수정

### DIFF
--- a/src/components/Header/UrlInputContainer.jsx
+++ b/src/components/Header/UrlInputContainer.jsx
@@ -11,15 +11,7 @@ function UrlInputContainer({
   const textareaRef = useRef();
 
   const handleURLInput = async (event) => {
-    let pasteValue = "";
-
-    if (event.clipboardData) {
-      pasteValue = event.clipboardData.getData("text");
-    } else if (window.clipboardData) {
-      pasteValue = window.clipboardData.getData("text");
-    }
-
-    const inputValue = pasteValue || textareaRef.current.value;
+    const inputValue = textareaRef.current.value;
     const trimmedInputValue = inputValue.trim();
     const urls = trimmedInputValue.match(/(https?:\/\/[^\s]+)/g) || [];
     const otherValues = trimmedInputValue
@@ -36,10 +28,8 @@ function UrlInputContainer({
       return;
     }
 
-    if (event.keyCode === 13 || pasteValue) {
+    if (event.keyCode === 13) {
       event.preventDefault();
-      textareaRef.current.value = "";
-      handleResizeHeight(textareaRef);
 
       const promises = inputValues.map((input) =>
         handleSingleURL(input, articleDataList, setMessageList),
@@ -52,6 +42,9 @@ function UrlInputContainer({
         ...newestArticleDataList,
         ...articleDataList,
       ];
+
+      textareaRef.current.value = "";
+      handleResizeHeight(textareaRef);
 
       window.localStorage.setItem(
         "URLs",


### PR DESCRIPTION
## 개요
#37

1. API 요청 시, 더이상 붙여넣기로 트리거 되지 않습니다.
2. API 요청 후, 응답이 올때까지 입력창이 초기화되지 않습니다.

## 코드 변경 사항
1. API 요청이 더이상 붙여넣기로 트리거 되지 않습니다.
https://github.com/team-sticky-252/readim-client/blob/886982be20e532c261326ae254f9232c7f698c24/src/components/Header/UrlInputContainer.jsx#L31-L36
2. API 요청 후, 응답이 오고난 후 입력창이 초기화됩니다.
https://github.com/team-sticky-252/readim-client/blob/886982be20e532c261326ae254f9232c7f698c24/src/components/Header/UrlInputContainer.jsx#L34-L48


## 기타 전달 사항

<!---- 리뷰어들에게 기능관련 외에 전달하고 싶은 사항을 작성해주세요. -->

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
