### PR TITLE
Feat: Summary 컴포넌트 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
   const [messageList, setMessageList] = useState([]);
   const [articleDataList, setArticleDataList] = useState([]);
   const [articleSummaryData, setArticleSummaryData] = useState({
+    id: "",
     favicon: "",
     domain: "",
     articleTitle: "",

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -8,6 +8,7 @@ import ReadingTime from "./ReadingTime";
 import IconButton from "../shared/Button/IconButton";
 
 function Card({
+  id,
   favicon = "/readimFavicon.png",
   domain,
   articleTitle,
@@ -41,6 +42,7 @@ function Card({
 
   const handleShowSummaryClick = () => {
     setArticleSummaryData({
+      id,
       favicon,
       domain,
       articleTitle,
@@ -88,6 +90,7 @@ function Card({
 export default Card;
 
 Card.propTypes = {
+  id: PropTypes.string.isRequired,
   favicon: PropTypes.string,
   domain: PropTypes.string.isRequired,
   articleTitle: PropTypes.string.isRequired,

--- a/src/components/Card/CardContainer.jsx
+++ b/src/components/Card/CardContainer.jsx
@@ -12,6 +12,7 @@ function CardContainer({
       {articleDataList.map((article) => (
         <Card
           key={article.id}
+          id={article.id}
           favicon={article.faviconUrl}
           domain={article.siteName}
           articleTitle={article.title}

--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -32,7 +32,7 @@ function Summary({
       JSON.parse(window.sessionStorage.getItem("summarys")) || {};
     const articleId = articleSummaryData?.id;
 
-    if (summaryDatas?.[articleId]) {
+    if (summaryDatas[articleId]) {
       setSummaryText(summaryDatas[articleId]);
     } else {
       generateResponse(articleSummaryData.mainContent)

--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -12,6 +12,7 @@ const SummaryResult = lazy(() => import("./SummaryResult"));
 function Summary({
   setArticleSummaryData,
   articleSummaryData = {
+    id: "",
     favicon: "",
     domain: "",
     articleTitle: "",
@@ -27,14 +28,32 @@ function Summary({
   const [summaryError, setSummaryError] = useState(null);
 
   useEffect(() => {
-    generateResponse(articleSummaryData.mainContent)
-      .then((summary) => {
-        setSummaryText(summary);
-      })
-      .catch(() => {
-        setSummaryError("요약 생성 중 에러가 발생했습니다. 다시 시도해주세요.");
-      });
-  }, [articleSummaryData.mainContent]);
+    const summaryDatas =
+      JSON.parse(window.sessionStorage.getItem("summarys")) || {};
+    const articleId = articleSummaryData?.id;
+
+    if (summaryDatas?.[articleId]) {
+      setSummaryText(summaryDatas[articleId]);
+    } else {
+      generateResponse(articleSummaryData.mainContent)
+        .then((summary) => {
+          setSummaryText(summary);
+
+          setTimeout(() => {
+            summaryDatas[articleSummaryData.id] = summary;
+            window.sessionStorage.setItem(
+              "summarys",
+              JSON.stringify(summaryDatas),
+            );
+          }, 0);
+        })
+        .catch(() => {
+          setSummaryError(
+            "요약 생성 중 에러가 발생했습니다. 다시 시도해주세요.",
+          );
+        });
+    }
+  }, [articleSummaryData]);
 
   const handleCloseSummaryClick = () => {
     setMessageFadeAnimation("animate-slide-out-left");

--- a/src/components/Summary/SummaryContainer.jsx
+++ b/src/components/Summary/SummaryContainer.jsx
@@ -4,6 +4,7 @@ import Summary from "./Summary";
 function SummaryContainer({
   setArticleSummaryData,
   articleSummaryData = {
+    id: "",
     favicon: "",
     domain: "",
     articleTitle: "",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -8,18 +8,19 @@ const openai = new OpenAI({
 });
 
 async function generateResponse(prompt) {
-  const response = await openai.completions.create({
-    model: "gpt-3.5-turbo-instruct",
-    prompt: `${prompt}
-    ---
-    Please translate the above sentence into Korean using the OpenAI API.
-    Focus strictly on summarizing the core content in the translation within 300 characters.
-    Exclude any unrelated information or filler text, and utilize the provided max_tokens effectively for accuracy.`,
+  const response = await openai.chat.completions.create({
+    model: "gpt-4-turbo",
+    messages: [
+      {
+        role: "user",
+        content: `${prompt} --- Please translate the above sentence into Korean using the OpenAI API. Focus strictly on summarizing the core content in the translation within 300 characters. Exclude any unrelated information or filler text, and utilize the provided max_tokens effectively for accuracy.`,
+      },
+    ],
     max_tokens: 300,
   });
 
   if (response?.choices?.length > 0) {
-    return response.choices[0].text.trim();
+    return response.choices[0].message.content.trim();
   }
 
   throw new Error("Invalid response format or empty choices array");


### PR DESCRIPTION
## 개요
특정 아티클의 요약을 보여주는 Summary 컴포넌트에 기능을 추가하였습니다.

## 코드 변경 사항
- 아티클 요약 요청시 id 값을 함께 넘겨 이후 요약글을 session storage에서 꺼내올 수 있도록 하였습니다.
https://github.com/team-sticky-252/readim-client/blob/79a0e6833af8811f6c2cdae5f0d57d868e2ef763/src/components/Card/Card.jsx#L43-L45
- session storage에 저장된 요약글이 있는 경우를 판별해 API 요청을 최소화 할 수 있도록 작성했습니다.
https://github.com/team-sticky-252/readim-client/blob/79a0e6833af8811f6c2cdae5f0d57d868e2ef763/src/components/Summary/Summary.jsx#L31-L54

## 기타 전달 사항
해당 문서의 내용이 변경되거나 업데이트 되는 경우를 고려하여 반영구적인 local storage 보다 session storage를 선택하였습니다.

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
