### PR TITLE
Test: 읽기 속도 비교 모달창 추가로 인한 테스트 코드 수정

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -35,23 +35,23 @@ describe("Readim 첫 방문시 초기화면", () => {
     });
 
     it("읽기 측정 테스트를 30초에 완료하면 wpm은 406이다.", () => {
-      completeReadingTest(30000, "406");
+      completeReadingTest(30000, "406", "/modal/result");
     });
 
     it("읽기 측정 테스트를 24초에 완료하면 wpm은 기본값인 202다.", () => {
-      completeReadingTest(24000, "202");
+      completeReadingTest(24000, "202", "/");
     });
 
     it("읽기 측정 테스트를 2분 25초에 완료하면 wpm은 84이다.", () => {
-      completeReadingTest(145000, "84");
+      completeReadingTest(145000, "84", "/modal/result");
     });
 
     it("읽기 측정 테스트를 2분 26초에 완료하면 wpm은 기본값인 202다.", () => {
-      completeReadingTest(146000, "202");
+      completeReadingTest(146000, "202", "/");
     });
   });
 
-  const completeReadingTest = (tickTime, expectedWpm) => {
+  const completeReadingTest = (tickTime, expectedWpm, path) => {
     cy.visit("/modal/test");
 
     cy.clock();
@@ -64,7 +64,7 @@ describe("Readim 첫 방문시 초기화면", () => {
     cy.getBySel("test-next-button").should("not.be.disabled");
     cy.getBySel("test-next-button").click();
 
-    cy.url().should("eq", `http://localhost:5173/`);
+    cy.url().should("eq", `http://localhost:5173${path}`);
     cy.window()
       .its("localStorage")
       .then((localStorage) => {


### PR DESCRIPTION
## 개요
[Feat: 읽기 속도 비교 모달창 구현](https://github.com/team-sticky-252/readim-client/pull/31)에서 추가된 결과 모달창과 관련된 테스트 코드를 수정했습니다.

## 코드 변경 사항
- `completeReadingTest()` 함수의 parameter에 path를 추가했습니다.
https://github.com/team-sticky-252/readim-client/blob/0d6022fda0efde0b9cee7ba5ac95d6d76e1e82bc/cypress/e2e/spec.cy.js#L54-L67

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
