### PR TITLE
Feat: reading time API 요청시 로딩 및 입력 방지 기능 구현

### DIFF
--- a/src/components/Header/UrlInputContainer.jsx
+++ b/src/components/Header/UrlInputContainer.jsx
@@ -83,8 +83,8 @@ function UrlInputContainer({
       <button
         id="requestButton"
         className={`h-8 m-2 rounded group ${!isLoading && "hover:bg-zinc-100"}`}
-        aria-label="save url"
-        title="save"
+        aria-label="request url"
+        title="request button"
         onClick={handleURLInput}
       >
         {!isLoading && (

--- a/src/components/Header/UrlInputContainer.jsx
+++ b/src/components/Header/UrlInputContainer.jsx
@@ -1,5 +1,7 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import PropTypes from "prop-types";
+import { ImSpinner3 } from "react-icons/im";
+import { BsArrowReturnLeft } from "react-icons/bs";
 
 import { handleSingleURL, handleResizeHeight } from "../../utils/urlUtils";
 
@@ -8,6 +10,7 @@ function UrlInputContainer({
   setArticleDataList,
   setMessageList,
 }) {
+  const [isLoading, setIsLoading] = useState(false);
   const textareaRef = useRef();
 
   const handleURLInput = async (event) => {
@@ -28,7 +31,8 @@ function UrlInputContainer({
       return;
     }
 
-    if (event.keyCode === 13) {
+    if (event.keyCode === 13 || event.currentTarget.id === "requestButton") {
+      setIsLoading(true);
       event.preventDefault();
 
       const handleSingleResult = (result) => {
@@ -53,6 +57,7 @@ function UrlInputContainer({
         );
 
         handleSingleResult(result);
+        setIsLoading(false);
       });
 
       textareaRef.current.value = "";
@@ -61,17 +66,34 @@ function UrlInputContainer({
   };
 
   return (
-    <div className="flex items-center justify-center m-auto mx-auto mt-4 bg-white border shadow-md mb-14 border-light-gray w-fit rounded-xl">
+    <div
+      className={`flex items-center justify-center m-auto mx-auto mt-4 ${isLoading ? "bg-[#fafafa]" : "bg-white"} border shadow-md mb-14 border-light-gray w-fit rounded-xl`}
+    >
       <textarea
         ref={textareaRef}
         rows={1}
         onChange={() => handleResizeHeight(textareaRef)}
         onKeyDown={handleURLInput}
         onPaste={handleURLInput}
-        className="m-3 mx-5 text-base font-thin outline-none resize-none w-118"
+        className="my-3 ml-5 text-base font-thin outline-none resize-none w-118"
         placeholder="URL을 입력해 주세요."
         data-test="test-inputWindow"
+        disabled={isLoading}
       />
+      <button
+        id="requestButton"
+        className={`h-8 m-2 rounded group ${!isLoading && "hover:bg-zinc-100"}`}
+        aria-label="save url"
+        title="save"
+        onClick={handleURLInput}
+      >
+        {!isLoading && (
+          <BsArrowReturnLeft className="w-8 text-zinc-400 group-hover:text-gray" />
+        )}
+        {isLoading && (
+          <ImSpinner3 size={18} className="w-8 animate-spin text-gray" />
+        )}
+      </button>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -148,3 +148,7 @@
 *::-webkit-scrollbar-track {
   background: transparent;
 }
+
+textarea:disabled {
+  background-color: #fafafa;
+}


### PR DESCRIPTION
## 개요
url 입력 버튼을 작성하고 관련 기능을 추가했습니다.

## 코드 변경 사항
- 모바일 대응을 고려해 url 입력시 클릭 할 수 있는 버튼을 추가했습니다.
- `isLoading` 상태를 통해 url 요청시 로딩 아이콘을 표시할 수 있도록 하였습니다.
https://github.com/team-sticky-252/readim-client/blob/3794d0379567b1b658e808fbd0ca009bc26cfd50/src/components/Header/UrlInputContainer.jsx#L90-L95
- url 요청 중인 경우 textarea 를 disabled 하도록 속성을 추가했습니다.
https://github.com/team-sticky-252/readim-client/blob/3794d0379567b1b658e808fbd0ca009bc26cfd50/src/components/Header/UrlInputContainer.jsx#L81

## 기타 전달 사항
- 브라우저별 다른 disabled color 를 통일 할 수 있도록 색상을 추가했습니다.
https://github.com/team-sticky-252/readim-client/blob/3794d0379567b1b658e808fbd0ca009bc26cfd50/src/index.css#L152-L154

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
