### PR TITLE
Refactor: reading time 초 단위 반올림 로직 변경

### DIFF
--- a/src/components/Card/ReadingTime.jsx
+++ b/src/components/Card/ReadingTime.jsx
@@ -1,18 +1,8 @@
 import PropTypes from "prop-types";
 
 function ReadingTime({ readingTime }) {
-  let readingMinute = Math.floor(readingTime / 1000 / 60);
-  let readingSeconds =
-    Math.round((readingTime / 1000 - readingMinute * 60) * 0.1) * 10;
-
-  if (readingSeconds >= 45) {
-    readingMinute += 1;
-    readingSeconds = 0;
-  } else if (readingSeconds >= 15) {
-    readingSeconds = 30;
-  } else {
-    readingSeconds = 0;
-  }
+  const readingMinute = Math.floor(readingTime / 1000 / 60);
+  const readingSeconds = Math.floor(readingTime / 1000 - readingMinute * 60);
 
   return (
     <div className="my-3">

--- a/src/components/Header/InfoReadingTimeText.jsx
+++ b/src/components/Header/InfoReadingTimeText.jsx
@@ -2,10 +2,9 @@ import PropTypes from "prop-types";
 
 function InfoReadingTimeText({ totalReadTime }) {
   let readingMinute = Math.floor(totalReadTime / 1000 / 60);
-  const readingSeconds =
-    Math.round((totalReadTime / 1000 - readingMinute * 60) * 0.1) * 10;
+  const readingSeconds = Math.floor(totalReadTime / 1000 - readingMinute * 60);
 
-  if (readingSeconds >= 30) {
+  if (readingSeconds > 0) {
     readingMinute += 1;
   }
 


### PR DESCRIPTION
## 개요
- 현재 0초, 30초 단위로 변환하여 화면에 보여주는 것을 초 단위 그대로 화면에 나타내기 위해 로직을 수정했습니다.

## 코드 변경 사항
- 카드 내에 보이는 아티클의 예상 읽기 시간은 초 단위 반올림 없이 그대로 화면에 노출했습니다.
https://github.com/team-sticky-252/readim-client/blob/cfb660e28d6b57187df48fff16aa38894a2c6ddb/src/components/Card/ReadingTime.jsx#L4-L5

- 총 읽기 시간은 올림으로 변경했습니다.
https://github.com/team-sticky-252/readim-client/blob/cfb660e28d6b57187df48fff16aa38894a2c6ddb/src/components/Header/InfoReadingTimeText.jsx#L4-L9

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
