### PR TITLE
Design: 링크 영역 카드 전체로 수정

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -54,10 +54,15 @@ function Card({
 
   return (
     <li
-      className={`relative flex flex-col content-center w-48 p-5 list-none transition-all bg-white shadow-md ${isDeleted ? "animate-fade-out" : "animate-scale-in-center"} h-52 shadow-black/25 rounded-3xl group hover:scale-115`}
+      className={`relative flex flex-col content-center w-48 list-none transition-all bg-white shadow-md ${isDeleted ? "animate-fade-out" : "animate-scale-in-center"} h-52 shadow-black/25 rounded-3xl group hover:scale-115`}
       data-test="test-articleCard"
     >
-      <a href={url} target="_blank" className="relative" rel="noreferrer">
+      <a
+        href={url}
+        target="_blank"
+        className="relative h-full p-5"
+        rel="noreferrer"
+      >
         <div className="flex items-center">
           <img
             className="inline-block w-4 h-4"
@@ -68,7 +73,11 @@ function Card({
           <p className="text-[11px] w-4/5 truncate inline-block ml-1 font-medium">
             {domain}
           </p>
-          {isCertifiedSite() && <GradientPatchCheckIcon />}
+          {isCertifiedSite() && (
+            <div className="absolute top-4 right-5">
+              <GradientPatchCheckIcon />
+            </div>
+          )}
         </div>
         <ReadingTime readingTime={readingTime} />
         <p className="mt-6 mr-1 text-sm group-hover:pointed-title font-extralight title-ellipsis">
@@ -77,7 +86,7 @@ function Card({
       </a>
       <button
         aria-label="openAI-summary"
-        className="absolute bottom-5 right-5 text-gray hover:text-black"
+        className="absolute p-1 bottom-4 right-4 text-gray hover:text-black"
         onClick={handleShowSummaryClick}
       >
         <SiOpenai />

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -86,7 +86,7 @@ function Card({
       </a>
       <button
         aria-label="openAI-summary"
-        className="absolute p-1 bottom-4 right-4 text-gray hover:text-black"
+        className="absolute p-1 bottom-4 right-4 text-gray hover:text-black hover:bg-medium-gray hover:rounded-lg"
         onClick={handleShowSummaryClick}
       >
         <SiOpenai />

--- a/src/components/shared/GradientPatchCheckIcon.jsx
+++ b/src/components/shared/GradientPatchCheckIcon.jsx
@@ -4,7 +4,7 @@ import { BsPatchCheckFill } from "react-icons/bs";
 
 function GradientPatchCheckIcon() {
   return (
-    <div>
+    <>
       <svg width="0" height="0">
         <defs>
           <linearGradient
@@ -29,7 +29,7 @@ function GradientPatchCheckIcon() {
       <BsPatchCheckFill
         style={{ fill: "url(#gradient1)", width: "1rem", height: "1.5rem" }}
       />
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 개요
- 테스터의 의견을 반영하여 카드 컴포넌트의 전체 영역이 링크 영역이 되도록 반영합니다.

## 코드 변경 사항
- 링크 영역이 카드 전체가 되도록 수정했습니다.
- summary 버튼에 padding 영역을 주었습니다.
  - 그에 맞게 파비콘, 인증 마크, summary 버튼이 정렬 되도록 수정했습니다.

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
