### PR TITLE
Fix: 상태 업데이트시 summary 컴포넌트 렌더링 오류 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ function App() {
     mainContent: "",
     url: "",
   });
+  const [isSummaryClosed, setIsSummaryClosed] = useState(true);
 
   const navigate = useNavigate();
 
@@ -95,8 +96,9 @@ function App() {
         <div className="w-216">
           {articleDataList.length === 0 && <Welcome />}
           <SummaryContainer
-            key={crypto.randomUUID()}
             articleSummaryData={articleSummaryData}
+            isSummaryClosed={isSummaryClosed}
+            setIsSummaryClosed={setIsSummaryClosed}
           />
           <HeaderContainer
             articleDataList={articleDataList}
@@ -107,6 +109,8 @@ function App() {
             articleDataList={articleDataList}
             setArticleSummaryData={setArticleSummaryData}
             deleteArticle={deleteArticle}
+            isSummaryClosed={isSummaryClosed}
+            setIsSummaryClosed={setIsSummaryClosed}
           />
           <ToastContainer
             messageList={messageList}

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -126,4 +126,6 @@ Card.propTypes = {
   url: PropTypes.string.isRequired,
   deleteArticle: PropTypes.func.isRequired,
   setArticleSummaryData: PropTypes.func.isRequired,
+  isSummaryClosed: PropTypes.bool.isRequired,
+  setIsSummaryClosed: PropTypes.func.isRequired,
 };

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -17,6 +17,8 @@ function Card({
   url,
   deleteArticle,
   setArticleSummaryData,
+  isSummaryClosed,
+  setIsSummaryClosed,
 }) {
   const [isDeleted, setIsDeleted] = useState();
 
@@ -40,7 +42,8 @@ function Card({
     }, 500);
   };
 
-  const handleShowSummaryClick = () => {
+  const setArticleSummary = () => {
+    setIsSummaryClosed(false);
     setArticleSummaryData({
       id,
       favicon,
@@ -50,6 +53,15 @@ function Card({
       mainContent,
       url,
     });
+  };
+
+  const handleShowSummaryClick = () => {
+    if (!isSummaryClosed) {
+      setIsSummaryClosed(true);
+
+      setTimeout(setArticleSummary, 500);
+    }
+    setArticleSummary();
   };
 
   return (

--- a/src/components/Card/CardContainer.jsx
+++ b/src/components/Card/CardContainer.jsx
@@ -50,4 +50,6 @@ CardContainer.propTypes = {
   ).isRequired,
   deleteArticle: PropTypes.func.isRequired,
   setArticleSummaryData: PropTypes.func.isRequired,
+  isSummaryClosed: PropTypes.bool.isRequired,
+  setIsSummaryClosed: PropTypes.func.isRequired,
 };

--- a/src/components/Card/CardContainer.jsx
+++ b/src/components/Card/CardContainer.jsx
@@ -6,6 +6,8 @@ function CardContainer({
   articleDataList,
   deleteArticle,
   setArticleSummaryData,
+  isSummaryClosed,
+  setIsSummaryClosed,
 }) {
   return (
     <main
@@ -24,6 +26,8 @@ function CardContainer({
           url={article.url}
           deleteArticle={() => deleteArticle(article.id)}
           setArticleSummaryData={setArticleSummaryData}
+          isSummaryClosed={isSummaryClosed}
+          setIsSummaryClosed={setIsSummaryClosed}
         />
       ))}
     </main>

--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -120,4 +120,5 @@ Summary.propTypes = {
     mainContent: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  setIsSummaryClosed: PropTypes.func.isRequired,
 };

--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -19,7 +19,7 @@ function Summary({
     mainContent: "",
     url: "",
   },
-  setIsClosed,
+  setIsSummaryClosed,
 }) {
   const [messageFadeAnimation, setMessageFadeAnimation] = useState(
     "animate-slide-in-left",
@@ -32,7 +32,7 @@ function Summary({
     setMessageFadeAnimation("animate-slide-out-left");
 
     setTimeout(() => {
-      setIsClosed(true);
+      setIsSummaryClosed(true);
     }, 500);
   };
 

--- a/src/components/Summary/SummaryContainer.jsx
+++ b/src/components/Summary/SummaryContainer.jsx
@@ -41,4 +41,6 @@ SummaryContainer.propTypes = {
     mainContent: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  isSummaryClosed: PropTypes.bool.isRequired,
+  setIsSummaryClosed: PropTypes.func.isRequired,
 };

--- a/src/components/Summary/SummaryContainer.jsx
+++ b/src/components/Summary/SummaryContainer.jsx
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import React, { useState } from "react";
 import Summary from "./Summary";
 
 function SummaryContainer({
@@ -12,16 +11,17 @@ function SummaryContainer({
     mainContent: "",
     url: "",
   },
+  isSummaryClosed,
+  setIsSummaryClosed,
 }) {
-  const [isClosed, setIsClosed] = useState(false);
   return (
     <div>
-      {!isClosed && (
+      {!isSummaryClosed && (
         <aside className="fixed z-50 flex -translate-y-1/2 top-1/2 h-100vh left-7">
           {articleSummaryData?.articleTitle && (
             <Summary
               articleSummaryData={articleSummaryData}
-              setIsClosed={setIsClosed}
+              setIsSummaryClosed={setIsSummaryClosed}
             />
           )}
         </aside>


### PR DESCRIPTION
## 개요
Summary 컴포넌트 렌더링 이후 state 업데이트 시 Summary 컴포넌트가 렌더링 되는 오류를 수정하였습니다.

## 코드 변경 사항
- Summary 컴포넌트가 닫힘, 또는 열린 상태를 state로 관리해 구분할 수 있도록 하였습니다.

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
