### PR TITLE
Fix: API 요청 에러 처리 수정

### DIFF
--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -92,19 +92,17 @@ export const handleSingleURL = async (url, articleDataList, setMessageList) => {
       return articleData.data;
     }
   } catch (error) {
-    if (error.name === "AbortError") {
-      setMessageList((prev) => [
-        ...prev,
-        {
-          id: crypto.randomUUID(),
-          icon: ERROR_MESSAGE[408].icon,
-          messages: ERROR_MESSAGE[408].messages,
-          link: url,
-        },
-      ]);
-    } else {
-      throw error;
-    }
+    const errorCode = error.name === "AbortError" ? 408 : 500;
+
+    setMessageList((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        icon: ERROR_MESSAGE[errorCode].icon,
+        messages: ERROR_MESSAGE[errorCode].messages,
+        ...(errorCode === 408 && { link: url }),
+      },
+    ]);
   } finally {
     clearTimeout(fetchTimer);
   }


### PR DESCRIPTION
## 개요
- 서버가 켜지지 않은 상태에서 API 요청 시 로그에 에러 내용이 나타났지만 계속해서 입력창이 비활성화 되어있고 로딩 아이콘이 돌아가는 버그를 발견해 수정했습니다.

## 코드 변경 사항
- AbortError가 아닌 경우는 서버 에러 토스트 메시지를 띄우도록 수정했습니다.
https://github.com/team-sticky-252/readim-client/blob/c42262a8901a360b3519bc25b354d06b145436df/src/utils/urlUtils.js#L95-L105

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
