### PR TITLE
Fix: 모달창 외 영역 스크롤 이벤트 비활성화

### DIFF
--- a/src/components/Modal/ModalWrapper.jsx
+++ b/src/components/Modal/ModalWrapper.jsx
@@ -37,7 +37,7 @@ function ModalWrapper() {
   return (
     <>
       <div className="fixed top-0 left-0 w-full h-full opacity-60" />
-      <div className="modal-position">
+      <div className="z-10 modal-position">
         {statement === "test" && (
           <TestModal
             firstClickTimeMs={firstClickTimeMs}

--- a/src/components/Modal/TestModal.jsx
+++ b/src/components/Modal/TestModal.jsx
@@ -32,15 +32,11 @@ function TestModal({ navigateNextPage }) {
   };
 
   useEffect(() => {
-    const prevScrollY = preventScroll();
-
     if (testTextAreaRef.current) {
       testTextAreaRef.current.addEventListener("scroll", updateScroll);
     }
 
     return () => {
-      allowScroll(prevScrollY);
-
       if (testTextAreaRef.current) {
         testTextAreaRef.current.removeEventListener("scroll", updateScroll);
       }

--- a/src/components/shared/Modal/Modal.jsx
+++ b/src/components/shared/Modal/Modal.jsx
@@ -1,5 +1,8 @@
+import { useEffect } from "react";
 import { GoX } from "react-icons/go";
 import PropTypes from "prop-types";
+
+import { allowScroll, preventScroll } from "../../../utils/scrollUtils";
 
 function Modal({
   title,
@@ -9,6 +12,14 @@ function Modal({
   isDisabledButton,
   children,
 }) {
+  useEffect(() => {
+    const prevScrollY = preventScroll();
+
+    return () => {
+      allowScroll(prevScrollY);
+    };
+  }, []);
+
   return (
     <div className="p-10 bg-white shadow-md w-200 h-fit shadow-black/25 rounded-3xl">
       <button


### PR DESCRIPTION
## 개요
- 모달창 외 영역은 스크롤이 되지 않도록 합니다.
- z-index가 주어진 요소가 모달창 위로 보이는 것을 방지하기 위해 모달창에 z-index를 추가합니다.

## 코드 변경 사항
- TestModal에 있던 스크롤 이벤트 비활성화 로직을 공통 컴포넌트 Modal로 이동시켰습니다.
https://github.com/team-sticky-252/readim-client/blob/1ab3e23ff9c41e9870783a2275f8b5f08efccd93/src/components/shared/Modal/Modal.jsx#L15-L21

- 모달창에 z-index를 추가했습니다.
https://github.com/team-sticky-252/readim-client/blob/1ab3e23ff9c41e9870783a2275f8b5f08efccd93/src/components/Modal/ModalWrapper.jsx#L40

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
