### PR TITLE
Design: 안내 문구 팝업 추가 및 총 리딩 타임 문구 수정

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { FiMinus } from "react-icons/fi";
 import { SiOpenai } from "react-icons/si";
-import { BsChatSquareFill } from "react-icons/bs";
 import PropTypes from "prop-types";
 
 import GradientPatchCheckIcon from "../shared/GradientPatchCheckIcon";
@@ -100,7 +99,7 @@ function Card({
       <button
         aria-label="openAI-summary"
         data-hover="세줄 요약"
-        className="absolute p-1 hovertext bottom-4 right-4 text-gray hover:text-black hover:bg-medium-gray hover:rounded-lg"
+        className="absolute p-1 hover-text bottom-4 right-4 text-gray hover:text-black hover:bg-medium-gray hover:rounded-lg"
         onClick={handleShowSummaryClick}
       >
         <SiOpenai />

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FiMinus } from "react-icons/fi";
 import { SiOpenai } from "react-icons/si";
+import { BsChatSquareFill } from "react-icons/bs";
 import PropTypes from "prop-types";
 
 import GradientPatchCheckIcon from "../shared/GradientPatchCheckIcon";
@@ -98,7 +99,8 @@ function Card({
       </a>
       <button
         aria-label="openAI-summary"
-        className="absolute p-1 bottom-4 right-4 text-gray hover:text-black hover:bg-medium-gray hover:rounded-lg"
+        data-hover="세줄 요약"
+        className="absolute p-1 hovertext bottom-4 right-4 text-gray hover:text-black hover:bg-medium-gray hover:rounded-lg"
         onClick={handleShowSummaryClick}
       >
         <SiOpenai />

--- a/src/components/Header/InfoReadingTimeContainer.jsx
+++ b/src/components/Header/InfoReadingTimeContainer.jsx
@@ -5,8 +5,8 @@ function InfoReadingTimeContainer({ totalReadTime }) {
   return (
     <div className="flex items-end justify-center text-xl font-thin">
       약&nbsp;
-      <InfoReadingTimeText totalReadTime={totalReadTime} />의 아티클이
-      모여있어요.
+      <InfoReadingTimeText totalReadTime={totalReadTime} /> &nbsp;분량의
+      아티클이 모여있어요.
     </div>
   );
 }

--- a/src/components/Header/OptionButton.jsx
+++ b/src/components/Header/OptionButton.jsx
@@ -6,7 +6,7 @@ function OptionButton() {
   return (
     <div className="real">
       <button
-        className="fixed z-10 p-1 cursor-pointer hovertext group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg"
+        className="fixed z-10 p-1 cursor-pointer hover-text group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg"
         aria-label="open options"
         type="button"
         data-hover="읽기 속도 재측정"

--- a/src/components/Header/OptionButton.jsx
+++ b/src/components/Header/OptionButton.jsx
@@ -1,16 +1,15 @@
 import { IoSettingsSharp } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
-import TextButton from "../shared/Button/TextButton";
-
 function OptionButton() {
   const navigate = useNavigate();
   return (
     <div className="real">
       <button
-        className="fixed z-10 p-1 cursor-pointer group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg"
+        className="fixed z-10 p-1 cursor-pointer hovertext group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg"
         aria-label="open options"
         type="button"
+        data-hover="읽기 속도 재측정"
         onClick={() => navigate("/modal/guide")}
       >
         <IoSettingsSharp
@@ -18,11 +17,6 @@ function OptionButton() {
           size={22}
           filter="drop-shadow(1px 1px 2px rgb(0 0 0 / 0.25))"
         />
-        <span className="absolute w-max hidden top-0.5 right-9 group-hover:block">
-          <TextButton>
-            <span className="m-2 text-slate-700">읽기 속도 재측정</span>
-          </TextButton>
-        </span>
       </button>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -165,7 +165,7 @@ textarea:disabled {
   content: "";
 }
 
-.hovertext::before {
+.hover-text::before {
   content: attr(data-hover);
   font-size: 12px;
   visibility: hidden;
@@ -181,16 +181,14 @@ textarea:disabled {
   position: absolute;
   z-index: 1;
   transform: translate(-135%, -20%);
-  /* right: 120%;
-  bottom: 0%; */
 }
 
-.hovertext:hover::before {
+.hover-text:hover::before {
   opacity: 1;
   visibility: visible;
 }
 
-.hovertext.fixed::before {
+.hover-text.fixed::before {
   left: 80%;
   top: 25%;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -165,17 +165,13 @@ textarea:disabled {
   content: "";
 }
 
-.hovertext {
-  position: absolute;
-}
-
 .hovertext::before {
   content: attr(data-hover);
   font-size: 12px;
   visibility: hidden;
   opacity: 0;
   width: max-content;
-  background-color: rgba(120, 120, 120, 0.646);
+  background-color: rgba(104, 102, 102, 0.646);
   color: #fff;
   text-align: center;
   border-radius: 5px;
@@ -184,11 +180,18 @@ textarea:disabled {
 
   position: absolute;
   z-index: 1;
-  right: 120%;
-  bottom: 0%;
+  transform: translate(-135%, -20%);
+  /* right: 120%;
+  bottom: 0%; */
 }
 
 .hovertext:hover::before {
   opacity: 1;
   visibility: visible;
 }
+
+.hovertext.fixed::before {
+  left: 80%;
+  top: 25%;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -164,3 +164,31 @@ textarea:disabled {
 .code::after {
   content: "";
 }
+
+.hovertext {
+  position: absolute;
+}
+
+.hovertext::before {
+  content: attr(data-hover);
+  font-size: 12px;
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  background-color: rgba(120, 120, 120, 0.646);
+  color: #fff;
+  text-align: center;
+  border-radius: 5px;
+  padding: 3px 5px;
+  transition: opacity 0.3s ease-in-out;
+
+  position: absolute;
+  z-index: 1;
+  right: 120%;
+  bottom: 0%;
+}
+
+.hovertext:hover::before {
+  opacity: 1;
+  visibility: visible;
+}


### PR DESCRIPTION
## 개요

#51

1. 아티클 AI 요약 버튼, 읽기 속도 재측정 버튼에 마우스 오버 시 안내 문구가 팝업됩니다.
2. 아티클 등록 시, 총합 리딩 타임을 안내해주는 문구가 좀 더 명확하게 수정됐습니다.
  기존: "총 n분의 아티클이 모여있어요"
  변경: "총 n분 **분량의** 아티클이 모여있어요"

## 코드 변경 사항

- CSS 설정으로 팝업 노출로 인해 불필요해진 요소가 삭제됐습니다.
https://github.com/team-sticky-252/readim-client/blob/4420426093e1521160649fddf426f749348e3bc1/src/components/Header/OptionButton.jsx#L21-L25

## 기타 전달 사항

<!---- 리뷰어들에게 기능관련 외에 전달하고 싶은 사항을 작성해주세요. -->

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
