### PR TITLE
Chore: 배포 환경에서 새로고침 시 오류 페이지 보이는 현상 해결

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 /api/* http://readimtest03-env.eba-5ebns2mz.ap-northeast-2.elasticbeanstalk.com/:splat 200
+/* /index.html 200


### PR DESCRIPTION
## 개요
netlify로 배포한 후 주소가 /가 아닌 경우 새로고침 시 Page Not Found 화면이 보이고 있습니다.


## 코드 변경 사항
public/_redirects, netlify.toml 파일을 추가, 수정했습니다.


## 기타 전달 사항
- X

## PR Checklist

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
