### PR TITLE
Design: 헤더, ai 요약 모바일 대응

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,7 @@ function App() {
   };
 
   return (
-    <div className="relative flex flex-col items-center justify-between min-h-screen">
+    <div className="relative flex flex-col items-center justify-between min-h-screen overflow-x-hidden">
       <div className="flex justify-center h-auto min-h-full mb-auto">
         <div className="w-216 min-w-90 max-mobile:w-dvw max-mobile:flex max-mobile:flex-col max-mobile:justify-center max-mobile:p-5 max-mobile:pb-14">
           {articleDataList.length === 0 && <Welcome />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,7 +93,7 @@ function App() {
   return (
     <div className="relative flex flex-col items-center justify-between min-h-screen">
       <div className="flex justify-center h-auto min-h-full mb-auto">
-        <div className="w-216 max-mobile:w-dvw max-mobile:flex max-mobile:justify-center max-mobile:p-5">
+        <div className="w-216 min-w-90 max-mobile:w-dvw max-mobile:flex max-mobile:flex-col max-mobile:justify-center max-mobile:p-5 max-mobile:pb-14">
           {articleDataList.length === 0 && <Welcome />}
           <SummaryContainer
             articleSummaryData={articleSummaryData}

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -32,7 +32,7 @@ function Card({
   ];
 
   const cardResponsiveStyle =
-    "max-mobile:w-[40dvw] max-mobile:h-[40dvw] max-mobile:hover:scale-100";
+    "max-mobile:w-[40dvw] max-mobile:h-[40dvw] max-mobile:hover:scale-100 min-w-36 min-h-36";
   const cardTextResponsiveStyle = "max-mobile:mt-2 max-mobile:text-xs";
 
   const isCertifiedSite = () => {

--- a/src/components/Header/HeaderContainer.jsx
+++ b/src/components/Header/HeaderContainer.jsx
@@ -15,7 +15,7 @@ function HeaderContainer({
 
   return (
     <header className="grid w-full text-center text-centerborder-solid grid-row-3">
-      <OptionContainer />
+      <OptionContainer hasArticles={articleDataList.length > 0} />
       <InfoTextContainer totalReadTime={totalReadTime} />
       <UrlInputContainer
         articleDataList={articleDataList}

--- a/src/components/Header/InfoReadingTimeContainer.jsx
+++ b/src/components/Header/InfoReadingTimeContainer.jsx
@@ -4,7 +4,7 @@ import InfoReadingTimeText from "./InfoReadingTimeText";
 function InfoReadingTimeContainer({ totalReadTime }) {
   return (
     <div
-      className="flex items-end justify-center text-xl font-thin"
+      className="flex items-end justify-center text-xl font-thin max-mobile:text-lg"
       data-testid="total-reading-time"
     >
       약&nbsp;

--- a/src/components/Header/InfoTextContainer.jsx
+++ b/src/components/Header/InfoTextContainer.jsx
@@ -5,7 +5,7 @@ import InfoReadingTimeContainer from "./InfoReadingTimeContainer";
 function InfoTextContainer({ totalReadTime }) {
   return (
     <div
-      className={`flex relative bottom-6 justify-center ${totalReadTime > 0 && "h-28 max-mobile:h-8"}`}
+      className={`flex relative bottom-6 justify-center ${totalReadTime > 0 && "h-28 max-mobile:h-10"}`}
     >
       {totalReadTime > 0 && (
         <InfoReadingTimeContainer totalReadTime={totalReadTime} />

--- a/src/components/Header/InfoTextContainer.jsx
+++ b/src/components/Header/InfoTextContainer.jsx
@@ -5,7 +5,7 @@ import InfoReadingTimeContainer from "./InfoReadingTimeContainer";
 function InfoTextContainer({ totalReadTime }) {
   return (
     <div
-      className={`flex relative bottom-6 justify-center ${totalReadTime > 0 && "h-28"}`}
+      className={`flex relative bottom-6 justify-center ${totalReadTime > 0 && "h-28 max-mobile:h-8"}`}
     >
       {totalReadTime > 0 && (
         <InfoReadingTimeContainer totalReadTime={totalReadTime} />

--- a/src/components/Header/OptionButton.jsx
+++ b/src/components/Header/OptionButton.jsx
@@ -1,12 +1,12 @@
 import { IoSettingsSharp } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
-function OptionButton() {
+function OptionButton({ hasArticles }) {
   const navigate = useNavigate();
   return (
     <div className="real">
       <button
-        className="fixed z-10 p-1 cursor-pointer hover-text group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg max-mobile:static"
+        className={`fixed z-10 p-1 cursor-pointer hover-text group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg ${hasArticles && "max-mobile:sticky"}`}
         aria-label="open options"
         type="button"
         data-hover="읽기 속도 재측정"

--- a/src/components/Header/OptionButton.jsx
+++ b/src/components/Header/OptionButton.jsx
@@ -6,7 +6,7 @@ function OptionButton() {
   return (
     <div className="real">
       <button
-        className="fixed z-10 p-1 cursor-pointer hover-text group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg"
+        className="fixed z-10 p-1 cursor-pointer hover-text group peer top-5 right-5 hover:bg-medium-gray hover:rounded-lg max-mobile:static"
         aria-label="open options"
         type="button"
         data-hover="읽기 속도 재측정"

--- a/src/components/Header/OptionContainer.jsx
+++ b/src/components/Header/OptionContainer.jsx
@@ -2,7 +2,7 @@ import OptionButton from "./OptionButton";
 
 function OptionContainer() {
   return (
-    <div className="relative flex justify-end h-20">
+    <div className="relative flex justify-end h-20 max-mobile:h-14">
       <OptionButton />
     </div>
   );

--- a/src/components/Header/OptionContainer.jsx
+++ b/src/components/Header/OptionContainer.jsx
@@ -1,9 +1,9 @@
 import OptionButton from "./OptionButton";
 
-function OptionContainer() {
+function OptionContainer({ hasArticles }) {
   return (
-    <div className="relative flex justify-end h-20 max-mobile:h-14">
-      <OptionButton />
+    <div className="relative flex justify-end h-20 max-mobile:h-10">
+      <OptionButton hasArticles={hasArticles} />
     </div>
   );
 }

--- a/src/components/Header/UrlInputContainer.jsx
+++ b/src/components/Header/UrlInputContainer.jsx
@@ -67,7 +67,7 @@ function UrlInputContainer({
 
   return (
     <div
-      className={`flex relative items-center justify-center m-auto mx-auto bottom-4 ${isLoading ? "bg-[#fafafa]" : "bg-white"} border shadow-md mb-14 border-light-gray w-fit rounded-xl`}
+      className={`flex relative items-center justify-center m-auto mx-auto bottom-4 ${isLoading ? "bg-[#fafafa]" : "bg-white"} border shadow-md mb-14 border-light-gray w-136 max-mobile:w-[96%] max-mobile:mb-6 rounded-xl`}
     >
       <textarea
         ref={textareaRef}
@@ -75,7 +75,7 @@ function UrlInputContainer({
         onChange={() => handleResizeHeight(textareaRef)}
         onKeyDown={handleURLInput}
         onPaste={handleURLInput}
-        className="my-3 ml-5 text-base font-thin outline-none resize-none w-118"
+        className="w-full my-3 ml-5 text-base font-thin outline-none resize-none"
         placeholder="URL을 입력해 주세요."
         data-test="test-inputWindow"
         disabled={isLoading}

--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -78,7 +78,7 @@ function Summary({
 
   return (
     <div
-      className={`relative m-auto flex w-136 flex-col backdrop-blur-xl col-span-4 p-8 transition-all shadow-md rounded-3xl group shadow-black/25 ${messageFadeAnimation}`}
+      className={`relative m-auto flex w-136 flex-col backdrop-blur-xl col-span-4 p-8 transition-all shadow-md rounded-3xl group shadow-black/25 ${messageFadeAnimation} max-mobile:w-4/5 max-mobile:ml-0`}
       ref={summaryRef}
     >
       <div>

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -3,7 +3,7 @@ import InfoConceptText from "./Header/InfoConceptText";
 function Welcome() {
   return (
     <div className="flex justify-center mt-16">
-      <div className="w-3/5 font-thin text-7xl text-zinc-600">
+      <div className="w-3/5 font-thin text-7xl text-zinc-600 max-mobile:w-auto max-mobile:text-4xl">
         <p className="py-2">
           <span className="font-medium">Readim</span>은 시간을
         </p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ export default {
         216: "54rem",
       },
       minWidth: {
+        90: "22.5rem",
         160: "40rem",
       },
       zIndex: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,7 +60,7 @@ export default {
         115: "1.15",
       },
       screens: {
-        "max-mobile": { max: "430px" },
+        "max-mobile": { max: "640px" },
       },
       keyframes: {
         "slide-top": {


### PR DESCRIPTION
## 개요

모바일 대응을 위해 헤더와 관련된 컴포넌트의 CSS를 수정합니다.

## 코드 변경 사항

- 길이에 따라 URL 입력창의 길이가 변경됩니다.
- 모바일 크기의 경우 컨셉 문구의 폰트 크기가 text-7xl에서 text-4xl로 축소됩니다.
- 모바일 크기의 경우 우측 상단의 읽기 속도 재측정 버튼이 상단에 고정되어 스크롤 시 보이지 않습니다.
- 최저 해상도(360px) 미만일 경우 카드의 크기가 줄지 않도록 min-w-36 min-h-36를 추가했습니다.

## 기타 전달 사항

- X

## PR Checklist

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
