### PR TITLE
Test: Summary 관련 컴포넌트 단위 테스트 작성

### DIFF
--- a/src/components/Summary/Summary.jsx
+++ b/src/components/Summary/Summary.jsx
@@ -102,7 +102,10 @@ function Summary({
           />
         </div>
         <Suspense fallback={<SummarySkeleton />}>
-          <SummaryResult summaryText={summaryText} error={summaryError} />
+          <SummaryResult
+            summaryText={summaryText}
+            summaryError={summaryError}
+          />
         </Suspense>
       </div>
     </div>

--- a/src/spec/Summary.spec.jsx
+++ b/src/spec/Summary.spec.jsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import Summary from "../components/Summary/Summary";
+
+describe("Test Summary Component", () => {
+  const articleSummaryData = {
+    id: "1",
+    favicon: "https://example.com/favicon.ico",
+    domain: "example.com",
+    articleTitle: "Test Article",
+    readingTime: 5,
+    mainContent: "This is the content of the article.",
+    url: "https://example.com",
+  };
+
+  const setIsSummaryClosed = vi.fn();
+
+  it("setIsSummaryClosed called when the close button is clicked", async () => {
+    render(
+      <Summary
+        articleSummaryData={articleSummaryData}
+        setIsSummaryClosed={setIsSummaryClosed}
+      />,
+    );
+
+    const closeButton = screen.getByTitle("카드 삭제");
+    fireEvent.click(closeButton);
+
+    await waitFor(
+      () => {
+        expect(setIsSummaryClosed).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+});

--- a/src/spec/SummaryContainer.spec.jsx
+++ b/src/spec/SummaryContainer.spec.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import SummaryContainer from "../components/Summary/SummaryContainer";
+
+describe("Test SummaryContainer Component", () => {
+  const articleSummaryData = {
+    id: "1",
+    favicon: "https://example.com/favicon.ico",
+    domain: "example.com",
+    articleTitle: "Test Article",
+    readingTime: 5,
+    mainContent: "This is the content of the article.",
+    url: "https://example.com",
+  };
+
+  const setIsSummaryClosed = vi.fn();
+
+  it("renders correctly with given articleSummaryData", () => {
+    const { rerender } = render(
+      <SummaryContainer
+        articleSummaryData={articleSummaryData}
+        isSummaryClosed={false}
+        setIsSummaryClosed={setIsSummaryClosed}
+      />,
+    );
+
+    expect(
+      screen.getByText("Test Article의 내용을 요약해줘"),
+    ).toBeInTheDocument();
+    expect(screen.getByAltText("favicon")).toHaveAttribute(
+      "src",
+      articleSummaryData.favicon,
+    );
+
+    rerender(
+      <SummaryContainer
+        articleSummaryData={articleSummaryData}
+        isSummaryClosed={true}
+        setIsSummaryClosed={setIsSummaryClosed}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Test Article의 내용을 요약해줘"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByAltText("favicon")).not.toBeInTheDocument();
+  });
+});

--- a/src/spec/SummaryResult.spec.jsx
+++ b/src/spec/SummaryResult.spec.jsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+import Summary from "../components/Summary/Summary";
+
+import generateResponse from "../utils/api";
+
+describe("Test SummaryResult Component", () => {
+  const articleSummaryData = {
+    id: "1",
+    favicon: "https://example.com/favicon.ico",
+    domain: "example.com",
+    articleTitle: "Test Article",
+    readingTime: 5,
+    mainContent: "This is the content of the article.",
+    url: "https://example.com",
+  };
+
+  const setIsSummaryClosed = vi.fn();
+
+  beforeEach(() => {
+    vi.mock("../utils/api", () => ({
+      default: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("displays error message if generateResponse fails", async () => {
+    generateResponse.mockRejectedValueOnce(new Error());
+
+    render(
+      <Summary
+        articleSummaryData={articleSummaryData}
+        setIsSummaryClosed={setIsSummaryClosed}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "요약 생성 중 에러가 발생했습니다. 다시 시도해주세요.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls generateResponse and displays the summary text", async () => {
+    const summaryText = "This is a summary of the article.";
+    generateResponse.mockResolvedValueOnce(summaryText);
+
+    render(
+      <Summary
+        articleSummaryData={articleSummaryData}
+        setIsSummaryClosed={setIsSummaryClosed}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(summaryText)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
<!---- <타입>: <일감 명> 의 형식으로 제목 작성 -->

## 개요

Summary 컴포넌트 단위 테스트 코드를 작성합니다.

readim-client/src/components/Summary

- Summary.jsx
- SummaryContainer.jsx
- SummaryMessage.jsx
- SummaryResult.jsx
- SummarySkeleton.jsx

## 코드 변경 사항
https://github.com/team-sticky-252/readim-client/blob/c743f8346080dddbcd34632a9c9246e320036788/src/components/Summary/Summary.jsx#L105-L107
- 기존 error에서 summaryError로 변경했습니다.

## 기타 전달 사항
- X

## PR Checklist

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
